### PR TITLE
Add ffmpeg fallback to ensure workflow completes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pyttsx3>=2.90",
     "python-dotenv>=1.0",
     "pydub>=0.25",
+    "imageio-ffmpeg>=0.4.9",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- resolve the ffmpeg binary at runtime so the video renderer can fall back to the bundled imageio-ffmpeg executable when the system binary is unavailable
- add imageio-ffmpeg as a core dependency so the workflow can render videos without a pre-installed ffmpeg

## Testing
- pytest -q
- python -m src.main

------
https://chatgpt.com/codex/tasks/task_e_68e8debcc9f88325899bc550c65cccec