### PR TITLE
Fix language label handling when stripping script code fences

### DIFF
--- a/src/steps/script.py
+++ b/src/steps/script.py
@@ -1,4 +1,5 @@
 import json
+import re
 import textwrap
 import yaml
 from pathlib import Path
@@ -107,6 +108,17 @@ class ScriptGenerator(Step):
 
         if cleaned.startswith("```") and cleaned.endswith("```"):
             cleaned = cleaned[3:-3]
+            cleaned = cleaned.lstrip()
+
+            first_line, separator, remainder = cleaned.partition("\n")
+            if separator:
+                candidate = first_line.strip()
+                if candidate and re.fullmatch(r"[a-zA-Z0-9_+\-.]+", candidate):
+                    cleaned = remainder.lstrip("\n")
+                else:
+                    cleaned = first_line + separator + remainder
+
+            cleaned = cleaned.strip()
 
         wrappers = [
             ('"""', '"""'),


### PR DESCRIPTION
## Summary
- strip optional language identifiers when unwrapping fenced LLM output
- ensure fenced blocks are cleaned before JSON/YAML parsing to avoid parse failures

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e8e12160ec8325a44e1362de6cdf9c