### PR TITLE
Fix Ken Burns frame duplication in video effects

### DIFF
--- a/src/providers/video_effects.py
+++ b/src/providers/video_effects.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Sequence, Tuple, Type
 
@@ -90,7 +91,7 @@ class KenBurnsEffect(VideoEffect):
         self.pan_mode = pan_mode
 
     def apply(self, stream: FilterableStream, context: VideoEffectContext) -> FilterableStream:
-        frames = max(int(context.fps * self.hold_frame_factor), 1)
+        frames = max(int(math.ceil(self.hold_frame_factor)), 1)
         x_expr, y_expr = self._resolve_pan_expressions(context)
 
         return stream.filter(

--- a/tests/unit/test_video_effects.py
+++ b/tests/unit/test_video_effects.py
@@ -31,7 +31,7 @@ class TestVideoEffectPipeline:
         call = stream.filter.call_args
         assert call.args[0] == "zoompan"
         assert call.kwargs["z"] == "min(zoom+0.01,1.3)"
-        assert call.kwargs["d"] == 12
+        assert call.kwargs["d"] == 1
         assert call.kwargs["s"] == "1280x720"
         assert "min(on/287,1)" in call.kwargs["x"]
         assert "ih/2 - (ih/zoom/2)" == call.kwargs["y"]


### PR DESCRIPTION
## Summary
- ensure the Ken Burns effect no longer multiplies its hold duration by the input FPS to avoid runaway frame duplication
- update the unit test expectation to cover the new frame hold behavior

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68e8ee889ef8832596623816d043bc33