### PR TITLE
Add configurable thumbnail overlays

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -65,10 +65,23 @@ steps:
     title_font_size: 96
     subtitle_font_size: 56
     font_path: "/usr/share/fonts/opentype/ipafont-gothic/ipag.ttf"
-    icon_path: "assets/icon2510youtuber-mini.png"
-    icon_size: 100
-    icon_position: "bottom_right"
-    icon_margin: 40
+    overlays:
+      - name: "character"
+        enabled: true
+        image_path: "assets/春日部つむぎ立ち絵_公式_v2.0/春日部つむぎ立ち絵_公式_v1.1.1.png"
+        anchor: "bottom_right"
+        height_ratio: 0.85
+        offset:
+          right: 20
+          bottom: 0
+      - name: "logo"
+        enabled: false
+        image_path: "assets/icon2510youtuber-mini.png"
+        anchor: "bottom_right"
+        height: 100
+        offset:
+          right: 40
+          bottom: 40
 
   metadata:
     enabled: true

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -63,6 +63,25 @@ class SubtitleStepConfig(BaseModel):
     max_visual_width: int
 
 
+class ThumbnailOverlayOffsetConfig(BaseModel):
+    top: int | None = None
+    right: int | None = None
+    bottom: int | None = None
+    left: int | None = None
+
+
+class ThumbnailOverlayConfig(BaseModel):
+    name: str | None = None
+    enabled: bool = True
+    image_path: str
+    anchor: str = "bottom_right"
+    height_ratio: float | None = None
+    width_ratio: float | None = None
+    height: int | None = None
+    width: int | None = None
+    offset: ThumbnailOverlayOffsetConfig | None = None
+
+
 class ThumbnailStepConfig(BaseModel):
     enabled: bool = False
     width: int
@@ -77,6 +96,8 @@ class ThumbnailStepConfig(BaseModel):
     title_font_size: int = 96
     subtitle_font_size: int = 56
     font_path: str | None = None
+    overlays: list[ThumbnailOverlayConfig] = Field(default_factory=list)
+    model_config = ConfigDict(extra="allow")
 
 
 class MetadataStepConfig(BaseModel):


### PR DESCRIPTION
## Summary
- add overlay configuration to thumbnail settings so each asset can be toggled from default.yaml
- teach ThumbnailGenerator to read the overlay list and composite enabled assets with configurable sizing and anchors
- refresh the thumbnail test script to load config-driven overlays and exercise the generator end-to-end

## Testing
- uv run pytest tests/unit/test_thumbnail.py -q
- uv run python test_character_thumbnail.py


------
https://chatgpt.com/codex/tasks/task_e_68e9c26b473c83258c04cd299a135d9d