### PR TITLE
Prevent thumbnail text from overlapping character art

### DIFF
--- a/src/steps/thumbnail.py
+++ b/src/steps/thumbnail.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List, Tuple
 
 from PIL import Image, ImageDraw, ImageFont
 
@@ -27,7 +27,10 @@ class ThumbnailGenerator(Step):
         self.padding = int(cfg.get("padding", 80))
         self.title_font_size = int(cfg.get("title_font_size", 96))
         self.subtitle_font_size = int(cfg.get("subtitle_font_size", 56))
+        self.max_lines = int(cfg.get("max_lines", 3))
+        self.max_chars_per_line = int(cfg.get("max_chars_per_line", 12))
         self.font_path = cfg.get("font_path")
+        self.overlay_configs = list(cfg.get("overlays", []))
 
     def execute(self, inputs: Dict[str, Path | str]) -> Path:
         output_path = self.get_output_path()
@@ -45,29 +48,37 @@ class ThumbnailGenerator(Step):
         title = self._resolve_title(metadata, script)
         subtitle = self._resolve_subtitle(metadata, script)
 
-        image = Image.new("RGB", (self.width, self.height), color=self.background_color)
+        image = Image.new("RGBA", (self.width, self.height), color=self.background_color)
         draw = ImageDraw.Draw(image)
 
+        overlays = self._prepare_overlays()
         title_font = self._load_font(self.title_font_size)
         subtitle_font = self._load_font(self.subtitle_font_size)
 
-        title_y = self.padding
-        draw.text((self.padding, title_y), title, fill=self.title_color, font=title_font)
+        text_right_edge = self._compute_text_right_edge(overlays)
+        title_bottom = self._render_text_block(draw, title, title_font, self.title_color, self.padding, text_right_edge)
+        self._render_text_block(
+            draw,
+            subtitle,
+            subtitle_font,
+            self.subtitle_color,
+            title_bottom + self.padding // 2,
+            text_right_edge,
+        )
 
-        subtitle_y = title_y + self.title_font_size + self.padding // 2
-        draw.text((self.padding, subtitle_y), subtitle, fill=self.subtitle_color, font=subtitle_font)
-
-        image.save(output_path, format="PNG")
+        self._apply_overlays(image, overlays)
+        image.convert("RGB").save(output_path, format="PNG")
         return output_path
 
     def _load_script(self, path: Path) -> Script:
-        with open(path, encoding="utf-8") as f:
-            data = json.load(f)
-        return Script(**data)
+        return Script(**self._read_json(path))
 
     def _load_metadata(self, path: Path) -> Dict:
+        return self._read_json(path, default={})
+
+    def _read_json(self, path: Path, default: Dict | None = None) -> Dict:
         if not path.exists():
-            return {}
+            return default or {}
         with open(path, encoding="utf-8") as f:
             return json.load(f)
 
@@ -95,3 +106,159 @@ class ThumbnailGenerator(Step):
             if font_file.exists():
                 return ImageFont.truetype(str(font_file), size)
         return ImageFont.load_default()
+
+    def _prepare_overlays(self) -> List[Dict]:
+        overlays: List[Dict] = []
+        for cfg in self.overlay_configs:
+            if not cfg.get("enabled", True):
+                continue
+            image_path = Path(str(cfg.get("image_path", "")))
+            if not image_path.exists():
+                continue
+            with Image.open(image_path) as overlay_image:
+                overlay = overlay_image.convert("RGBA")
+            overlay = self._scale_overlay(overlay, cfg)
+            position = self._resolve_overlay_position(overlay.size, cfg)
+            x, y = position
+            width, height = overlay.size
+            overlays.append(
+                {
+                    "image": overlay,
+                    "position": position,
+                    "bbox": (x, y, x + width, y + height),
+                    "anchor": str(cfg.get("anchor", "bottom_right")).lower(),
+                }
+            )
+        return overlays
+
+    def _scale_overlay(self, overlay: Image.Image, cfg: Dict) -> Image.Image:
+        width, height = overlay.size
+        target_width, target_height = width, height
+
+        if cfg.get("height"):
+            target_height = int(cfg["height"])
+            scale = target_height / height
+            target_width = int(width * scale)
+        elif cfg.get("width"):
+            target_width = int(cfg["width"])
+            scale = target_width / width
+            target_height = int(height * scale)
+        elif cfg.get("height_ratio"):
+            target_height = int(self.height * float(cfg["height_ratio"]))
+            scale = target_height / height
+            target_width = int(width * scale)
+        elif cfg.get("width_ratio"):
+            target_width = int(self.width * float(cfg["width_ratio"]))
+            scale = target_width / width
+            target_height = int(height * scale)
+
+        target_size = (max(1, target_width), max(1, target_height))
+        if target_size != overlay.size:
+            return overlay.resize(target_size, Image.LANCZOS)
+        return overlay
+
+    def _resolve_overlay_position(self, size: Tuple[int, int], cfg: Dict) -> Tuple[int, int]:
+        anchor = str(cfg.get("anchor", "bottom_right")).lower()
+        offset = cfg.get("offset") or {}
+
+        width, height = size
+        top = int(offset.get("top") or 0)
+        right = int(offset.get("right") or 0)
+        bottom = int(offset.get("bottom") or 0)
+        left = int(offset.get("left") or 0)
+
+        if "left" in anchor:
+            x = left
+        elif "right" in anchor:
+            x = self.width - width - right
+        else:
+            x = (self.width - width) // 2 + left - right
+
+        if "top" in anchor:
+            y = top
+        elif "bottom" in anchor:
+            y = self.height - height - bottom
+        else:
+            y = (self.height - height) // 2 + top - bottom
+
+        x = max(0, min(self.width - width, x))
+        y = max(0, min(self.height - height, y))
+        return int(x), int(y)
+
+    def _compute_text_right_edge(self, overlays: List[Dict]) -> int:
+        right_edge = self.width - self.padding
+        for overlay in overlays:
+            anchor = overlay.get("anchor", "")
+            if "right" in anchor:
+                candidate = overlay["bbox"][0] - self.padding // 2
+                right_edge = min(right_edge, candidate)
+        min_right = self.padding * 2
+        return max(min_right, right_edge)
+
+    def _render_text_block(
+        self,
+        draw: ImageDraw.ImageDraw,
+        text: str,
+        font: ImageFont.ImageFont,
+        color: str,
+        top: int,
+        right_edge: int,
+    ) -> int:
+        max_width = max(self.padding, right_edge - self.padding)
+        lines = self._wrap_text(text, font, max_width)
+        y = top
+        for index, line in enumerate(lines):
+            draw.text((self.padding, y), line, fill=color, font=font)
+            bbox = draw.textbbox((self.padding, y), line, font=font)
+            y = bbox[3]
+            if index < len(lines) - 1:
+                y += max(4, self.padding // 4)
+        return y
+
+    def _wrap_text(self, text: str, font: ImageFont.ImageFont, max_width: int) -> List[str]:
+        if max_width <= 0:
+            return [text[: self.max_chars_per_line]] if text else [""]
+
+        lines: List[str] = []
+        current = ""
+        for char in text:
+            if char == "\n":
+                if current:
+                    lines.append(current)
+                    if len(lines) >= self.max_lines:
+                        return lines[: self.max_lines]
+                current = ""
+                continue
+            tentative = current + char
+            if self._measure_text_width(font, tentative) <= max_width and len(tentative) <= self.max_chars_per_line:
+                current = tentative
+                continue
+            if current:
+                lines.append(current)
+                if len(lines) >= self.max_lines:
+                    return lines
+            current = char
+            if len(current) > self.max_chars_per_line or self._measure_text_width(font, current) > max_width:
+                lines.append(current)
+                current = ""
+                if len(lines) >= self.max_lines:
+                    return lines
+
+        if current and len(lines) < self.max_lines:
+            lines.append(current)
+
+        if not lines:
+            lines = [text[: self.max_chars_per_line]] if text else [""]
+        return lines[: self.max_lines]
+
+    def _measure_text_width(self, font: ImageFont.ImageFont, text: str) -> int:
+        if hasattr(font, "getlength"):
+            return int(font.getlength(text))
+        bbox = font.getbbox(text)
+        return int(bbox[2] - bbox[0])
+
+    def _apply_overlays(self, base_image: Image.Image, overlays: List[Dict]) -> None:
+        for overlay in overlays:
+            image = overlay["image"]
+            position = overlay["position"]
+            base_image.paste(image, position, mask=image)


### PR DESCRIPTION
## Summary
- reserve horizontal space for thumbnail text based on configured overlays and wrap long titles to avoid collisions
- render overlay images onto the thumbnail so standing artwork respects scaling and anchor offsets

## Testing
- pytest test_character_thumbnail.py

------
https://chatgpt.com/codex/tasks/task_e_68e9f4ca7ee883259969c69d4ccb0ee2