### PR TITLE
Modularize Discord workflow settings

### DIFF
--- a/config/discord.yaml
+++ b/config/discord.yaml
@@ -1,0 +1,30 @@
+news_bot:
+  environment_file: config/.env
+  token_env: DISCORD_BOT_TOKEN
+  command_name: news
+  command_description: "任意のニュースクエリを投入"
+  response_template: "📰 調査開始: `{query}`"
+  starter_template: "🧭 {query}"
+  thread_prefix: "ニュース調査: "
+  thread_name_limit: 40
+  thread_message: "ワークフローを実行します"
+  workflow_command:
+    - uv
+    - run
+    - python
+    - -m
+    - src.main
+  workflow_argument_flag: --news-query
+summary:
+  environment_file: config/.env
+  webhook_keys:
+    - DISCORD_WEBHOOK_URL
+  video_prefix: "📹 "
+  news_heading: "📰 今日のニュースまとめ:"
+  news_format: "- {title}：{summary}"
+  news_title_only_format: "- {title}"
+  youtube_base: "https://www.youtube.com/watch?v="
+  news_output_key: collect_news
+  video_output_key: upload_youtube
+  render_output_key: render_video
+  max_news: 3

--- a/scripts/discord_news_bot.py
+++ b/scripts/discord_news_bot.py
@@ -1,38 +1,72 @@
 import os
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import discord
 from discord import app_commands
 
-intents = discord.Intents.default()
-intents.message_content = True
+from src.utils.discord_config import load_discord_config, resolve_path
 
 
-class NewsClient(discord.Client):
-    def __init__(self):
-        super().__init__(intents=intents)
-        self.tree = app_commands.CommandTree(self)
+def load_environment(path: Path) -> None:
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if "=" not in line or line.lstrip().startswith("#"):
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip())
 
-    async def setup_hook(self):
-        await self.tree.sync()
 
-client = NewsClient()
-project_path = Path(__file__).resolve().parents[1]
-env_path = project_path / "config" / ".env"
-for line in env_path.read_text(encoding="utf-8").splitlines():
-    if line.startswith("#") or "=" not in line:
-        continue
-    key, value = line.split("=", 1)
-    os.environ.setdefault(key.strip(), value.strip())
+def workflow_command(settings: dict[str, Any], query: str) -> list[str]:
+    command = list(settings["workflow_command"])
+    command.extend([settings["workflow_argument_flag"], query])
+    return command
 
-@client.tree.command(name="news", description="任意のニュースクエリを投入")
-async def news(interaction: discord.Interaction, query: str):
-    await interaction.response.send_message(f"📰 調査開始: `{query}`", ephemeral=True)
-    channel = interaction.channel
-    starter = await channel.send(f"🧭 {query}")
-    thread = await starter.create_thread(name=f"ニュース調査: {query[:40]}")
-    await thread.send("ワークフローを実行します")
-    subprocess.Popen(["uv", "run", "python", "-m", "src.main", "--news-query", query], cwd=str(project_path))
 
-client.run(os.getenv("DISCORD_BOT_TOKEN"))
+def register_news_command(tree: app_commands.CommandTree, settings: dict[str, Any], project_root: Path) -> None:
+    response_template = settings["response_template"]
+    starter_template = settings["starter_template"]
+    thread_prefix = settings["thread_prefix"]
+    thread_name_limit = int(settings["thread_name_limit"])
+    thread_message = settings["thread_message"]
+    command = settings["command_name"]
+    description = settings["command_description"]
+
+    @tree.command(name=command, description=description)
+    async def handle(interaction: discord.Interaction, query: str) -> None:
+        await interaction.response.send_message(response_template.format(query=query), ephemeral=True)
+        starter = await interaction.channel.send(starter_template.format(query=query))
+        thread_name = f"{thread_prefix}{query[:thread_name_limit]}"
+        thread = await starter.create_thread(name=thread_name)
+        await thread.send(thread_message)
+        subprocess.Popen(workflow_command(settings, query), cwd=str(project_root))
+
+
+def create_client(settings: dict[str, Any], project_root: Path) -> discord.Client:
+    intents = discord.Intents.default()
+    intents.message_content = True
+
+    class Client(discord.Client):
+        def __init__(self) -> None:
+            super().__init__(intents=intents)
+            self.tree = app_commands.CommandTree(self)
+
+        async def setup_hook(self) -> None:
+            register_news_command(self.tree, settings, project_root)
+            await self.tree.sync()
+
+    return Client()
+
+
+def main() -> None:
+    config = load_discord_config()
+    news_settings: dict[str, Any] = config["news_bot"]
+    project_root = resolve_path(".")
+    load_environment(resolve_path(news_settings["environment_file"]))
+    token = os.environ[news_settings["token_env"]]
+    client = create_client(news_settings, project_root)
+    client.run(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_discord_news_bot.sh
+++ b/scripts/run_discord_news_bot.sh
@@ -1,19 +1,3 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-
-if [[ -f "${PROJECT_ROOT}/config/.env" ]]; then
-  set -a
-  source "${PROJECT_ROOT}/config/.env"
-  set +a
-fi
-
-cd "${PROJECT_ROOT}"
-
-if command -v uv >/dev/null 2>&1; then
-  exec uv run python scripts/discord_news_bot.py
-else
-  exec python scripts/discord_news_bot.py
-fi
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
+exec uv run python scripts/discord_news_bot.py

--- a/src/utils/discord.py
+++ b/src/utils/discord.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 from pathlib import Path
@@ -5,48 +7,67 @@ from typing import Iterable
 
 import requests
 
+from src.utils.discord_config import load_discord_config, resolve_path
+
+SUMMARY_SETTINGS = load_discord_config()["summary"]
+ENV_PATH = resolve_path(SUMMARY_SETTINGS["environment_file"])
+VIDEO_PREFIX = SUMMARY_SETTINGS["video_prefix"]
+NEWS_HEADING = SUMMARY_SETTINGS["news_heading"]
+NEWS_FORMAT = SUMMARY_SETTINGS["news_format"]
+NEWS_TITLE_ONLY_FORMAT = SUMMARY_SETTINGS["news_title_only_format"]
+YOUTUBE_BASE = SUMMARY_SETTINGS["youtube_base"]
+NEWS_OUTPUT_KEY = SUMMARY_SETTINGS["news_output_key"]
+VIDEO_OUTPUT_KEY = SUMMARY_SETTINGS["video_output_key"]
+RENDER_OUTPUT_KEY = SUMMARY_SETTINGS["render_output_key"]
+MAX_NEWS = int(SUMMARY_SETTINGS["max_news"])
+
+
+def _env_values(keys: Iterable[str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in ENV_PATH.read_text(encoding="utf-8").splitlines():
+        if "=" not in line or line.lstrip().startswith("#"):
+            continue
+        key, value = line.split("=", 1)
+        name = key.strip()
+        if name in keys and name not in values:
+            values[name] = value.strip()
+    return values
+
 
 def resolve_webhook(env_keys: Iterable[str] | None = None) -> str | None:
-    keys = tuple(env_keys or ("DISCORD_WEBHOOK_URL",))
+    keys = tuple(env_keys or SUMMARY_SETTINGS["webhook_keys"])
     for key in keys:
         value = os.getenv(key)
         if value:
             return value.strip()
-    project_root = Path(__file__).resolve().parents[2]
-    env_path = project_root / "config" / ".env"
-    if env_path.exists():
-        for line in env_path.read_text(encoding="utf-8").splitlines():
-            if line.startswith("#") or "=" not in line:
-                continue
-            key, value = line.split("=", 1)
-            if key.strip() in keys:
-                return value.strip()
+    values = _env_values(keys)
+    for key in keys:
+        if key in values:
+            return values[key]
     return None
 
 
 def _news_lines(path: Path, limit: int) -> list[str]:
-    if not path.exists():
-        return []
-    items = json.loads(path.read_text(encoding="utf-8"))
+    items = json.loads(path.read_text(encoding="utf-8"))[:limit]
     lines: list[str] = []
-    for item in items[:limit]:
+    for item in items:
         title = str(item.get("title", "")).strip()
         summary = str(item.get("summary", "")).strip()
-        if title and summary:
-            lines.append(f"- {title}：{summary}")
-        elif title:
-            lines.append(f"- {title}")
+        if not title:
+            continue
+        if summary:
+            lines.append(NEWS_FORMAT.format(title=title, summary=summary))
+        else:
+            lines.append(NEWS_TITLE_ONLY_FORMAT.format(title=title))
     return lines
 
 
 def _youtube_url(path: Path) -> str | None:
-    if not path.exists():
-        return None
     data = json.loads(path.read_text(encoding="utf-8"))
     if data.get("video_url"):
         return str(data["video_url"]).strip()
     if data.get("video_id"):
-        return f"https://www.youtube.com/watch?v={data['video_id']}"
+        return f"{YOUTUBE_BASE}{data['video_id']}"
     return None
 
 
@@ -55,25 +76,25 @@ def post_run_summary(
     outputs: dict[str, str],
     *,
     webhook_keys: Iterable[str] | None = None,
-    max_news: int = 3,
+    max_news: int | None = None,
 ) -> None:
     webhook = resolve_webhook(webhook_keys)
     if not webhook:
         return
-
-    news_lines = _news_lines(Path(outputs.get("collect_news", "")), max_news)
-    youtube_url = _youtube_url(Path(outputs.get("upload_youtube", "")))
-    if not youtube_url and outputs.get("render_video"):
-        youtube_url = str(outputs["render_video"])
-
+    news_path = outputs.get(NEWS_OUTPUT_KEY)
+    news_lines = _news_lines(Path(news_path), max_news or MAX_NEWS) if news_path else []
+    youtube_path = outputs.get(VIDEO_OUTPUT_KEY)
+    youtube_url = _youtube_url(Path(youtube_path)) if youtube_path else None
+    render_url = outputs.get(RENDER_OUTPUT_KEY)
+    if not youtube_url and render_url:
+        youtube_url = str(render_url)
     lines: list[str] = []
     if youtube_url:
-        lines.append(f"📹 {youtube_url}")
+        lines.append(f"{VIDEO_PREFIX}{youtube_url}")
     if news_lines:
-        lines.append("📰 今日のニュースまとめ:")
+        lines.append(NEWS_HEADING)
         lines.extend(news_lines)
     if not lines:
         return
-
     content = f"Run {run_id}\n" + "\n".join(lines)
     requests.post(webhook, json={"content": content}, timeout=5)

--- a/src/utils/discord_config.py
+++ b/src/utils/discord_config.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def resolve_path(value: str) -> Path:
+    candidate = Path(value)
+    return candidate if candidate.is_absolute() else PROJECT_ROOT / candidate
+
+
+@lru_cache
+def load_discord_config() -> dict[str, Any]:
+    config_path = Path(os.getenv("DISCORD_CONFIG_PATH", str(resolve_path("config/discord.yaml"))))
+    return yaml.safe_load(config_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- centralize Discord bot and summary configuration in `config/discord.yaml`
- refactor the Discord news bot script to load settings, modularize registration, and spawn the workflow via configurable commands
- simplify the launcher script and update Discord utilities to use shared configuration for formatting and webhook resolution

## Testing
- python -m compileall scripts/discord_news_bot.py src/utils/discord.py src/utils/discord_config.py

------
https://chatgpt.com/codex/tasks/task_e_68ec55dad8e48325956770bc3eda9fe0