### PR TITLE
Add Twitter clip posting workflow after YouTube upload

### DIFF
--- a/apps/youtube/cli.py
+++ b/apps/youtube/cli.py
@@ -14,6 +14,7 @@ from src.steps.script import ScriptGenerator
 from src.steps.subtitle import SubtitleFormatter
 from src.steps.thumbnail import ThumbnailGenerator
 from src.steps.video import VideoRenderer
+from src.steps.twitter import TwitterPoster
 from src.steps.youtube import YouTubeUploader
 from src.utils.config import Config
 from src.utils.discord import post_run_summary
@@ -132,6 +133,14 @@ def _build_steps(config: Config, run_id: str, run_dir: Path) -> List:
                 youtube_config=config.steps.youtube.model_dump(),
             )
         )
+        if config.steps.twitter.enabled:
+            steps.append(
+                TwitterPoster(
+                    run_id=run_id,
+                    run_dir=run_dir,
+                    twitter_config=config.steps.twitter.model_dump(),
+                )
+            )
 
     if config.steps.podcast.enabled:
         steps.append(

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -125,6 +125,16 @@ steps:
       - "ニュース"
       - "経済"
 
+  twitter:
+    enabled: true
+    dry_run: false
+    clip_duration_seconds: 60
+    thumbnail_path: "runs/20251015_183513/thumbnail.png"
+    api_key: "TWITTER_API_KEY"
+    api_secret: "TWITTER_API_SECRET"
+    access_token: "TWITTER_ACCESS_TOKEN"
+    access_secret: "TWITTER_ACCESS_SECRET"
+
   podcast:
     enabled: false
     feed_title: "金融ニュース解説ポッドキャスト"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "google-api-python-client>=2.0",
     "discord.py>=2.3",
     "feedgen>=1.0.0",
+    "tweepy>=4.14",
 ]
 
 [project.optional-dependencies]

--- a/src/providers/twitter.py
+++ b/src/providers/twitter.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import tweepy
+
+from src.utils.secrets import load_secret_values
+
+
+class TwitterClient:
+    def __init__(
+        self,
+        api_key: str,
+        api_secret: str,
+        access_token: str,
+        access_secret: str,
+        *,
+        dry_run: bool = False,
+    ) -> None:
+        self.dry_run = dry_run
+        auth = tweepy.OAuth1UserHandler(api_key, api_secret, access_token, access_secret)
+        self.api = tweepy.API(auth)
+
+    @staticmethod
+    def _secret(config: Dict, key: str) -> str:
+        name = config.get(key, "")
+        values = load_secret_values(name)
+        return values[0] if values else ""
+
+    @classmethod
+    def from_config(cls, config: Dict, *, dry_run: bool) -> "TwitterClient":
+        return cls(
+            cls._secret(config, "api_key"),
+            cls._secret(config, "api_secret"),
+            cls._secret(config, "access_token"),
+            cls._secret(config, "access_secret"),
+            dry_run=dry_run,
+        )
+
+    def post(self, text: str, video_path: Path, image_path: Path) -> Dict:
+        if self.dry_run:
+            return {
+                "status": text,
+                "video": str(video_path),
+                "image": str(image_path),
+            }
+        video_media = self.api.media_upload(filename=str(video_path), media_category="tweet_video")
+        image_media = self.api.media_upload(filename=str(image_path))
+        tweet = self.api.update_status(status=text, media_ids=[video_media.media_id_string, image_media.media_id_string])
+        return {
+            "id": tweet.id_str,
+            "text": tweet.text,
+            "media_ids": [video_media.media_id_string, image_media.media_id_string],
+        }

--- a/src/steps/twitter.py
+++ b/src/steps/twitter.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Dict
+
+from src.core.step import Step
+from src.providers.twitter import TwitterClient
+
+
+class TwitterPoster(Step):
+    name = "post_twitter"
+    output_filename = "tweet.json"
+    is_required = False
+
+    def __init__(
+        self,
+        run_id: str,
+        run_dir: Path,
+        twitter_config: Dict | None = None,
+    ) -> None:
+        super().__init__(run_id, run_dir)
+        twitter_config = twitter_config or {}
+        self.clip_duration = int(twitter_config.get("clip_duration_seconds", 60))
+        self.thumbnail_path = Path(twitter_config.get("thumbnail_path", "runs/20251015_183513/thumbnail.png"))
+        self.client = TwitterClient.from_config(twitter_config, dry_run=bool(twitter_config.get("dry_run", True)))
+
+    def execute(self, inputs: Dict[str, Path]) -> Path:
+        video_path = Path(inputs["render_video"])
+        metadata_path = Path(inputs["analyze_metadata"])
+        clip_path = self.run_dir / self.run_id / "twitter_clip.mp4"
+        clip_path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-i",
+                str(video_path),
+                "-t",
+                str(self.clip_duration),
+                "-c",
+                "copy",
+                str(clip_path),
+            ],
+            check=True,
+        )
+        payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+        tags = payload.get("tags", [])[:5]
+        suffix = " ".join(tags)
+        text = payload.get("title", "")
+        if suffix:
+            text = f"{text}\n{suffix}"
+        result = self.client.post(text, clip_path, self.thumbnail_path)
+        output_path = self.get_output_path()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
+        return output_path

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -179,6 +179,17 @@ class YouTubeStepConfig(BaseModel):
     default_tags: list[str] = Field(default_factory=list)
 
 
+class TwitterStepConfig(BaseModel):
+    enabled: bool = False
+    dry_run: bool = True
+    clip_duration_seconds: int = 60
+    thumbnail_path: str
+    api_key: str
+    api_secret: str
+    access_token: str
+    access_secret: str
+
+
 class PodcastStepConfig(BaseModel):
     enabled: bool = False
     feed_title: str = "金融ニュース解説ポッドキャスト"
@@ -205,6 +216,7 @@ class StepsConfig(BaseModel):
     thumbnail: ThumbnailStepConfig
     metadata: MetadataStepConfig
     youtube: YouTubeStepConfig
+    twitter: TwitterStepConfig
     podcast: PodcastStepConfig
     buzzsprout: BuzzsproutStepConfig
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -33,6 +33,8 @@ class TestConfig:
         assert isinstance(config.steps.metadata.llm_model, str)
         assert config.steps.metadata.llm_model != ""
         assert config.steps.youtube.enabled is True
+        assert config.steps.twitter.enabled is True
+        assert config.steps.twitter.clip_duration_seconds == 60
         assert config.steps.buzzsprout.enabled is False
 
     def test_providers_config(self):


### PR DESCRIPTION
## Summary
- add twitter step configuration and dependency management
- implement a Twitter client and step to post a clipped video with metadata-driven text
- trigger the Twitter posting step after successful YouTube uploads

## Testing
- pytest tests/unit/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68ef6d9c75208325bb1d9695df5177f4