### PR TITLE
Add Twitter clip posting after YouTube uploads

### DIFF
--- a/apps/youtube/cli.py
+++ b/apps/youtube/cli.py
@@ -15,6 +15,7 @@ from src.steps.subtitle import SubtitleFormatter
 from src.steps.thumbnail import ThumbnailGenerator
 from src.steps.video import VideoRenderer
 from src.steps.youtube import YouTubeUploader
+from src.steps.twitter import TwitterPoster
 from src.utils.config import Config
 from src.utils.discord import post_run_summary
 from src.utils.logger import get_logger
@@ -132,6 +133,15 @@ def _build_steps(config: Config, run_id: str, run_dir: Path) -> List:
                 youtube_config=config.steps.youtube.model_dump(),
             )
         )
+
+        if config.steps.twitter.enabled:
+            steps.append(
+                TwitterPoster(
+                    run_id=run_id,
+                    run_dir=run_dir,
+                    twitter_config=config.steps.twitter.model_dump(),
+                )
+            )
 
     if config.steps.podcast.enabled:
         steps.append(

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -125,6 +125,16 @@ steps:
       - "ニュース"
       - "経済"
 
+  twitter:
+    enabled: false
+    clip_duration_seconds: 60
+    chunk_size: 5242880
+    api_key_key: "TWITTER_API_KEY"
+    api_secret_key: "TWITTER_API_SECRET"
+    access_token_key: "TWITTER_ACCESS_TOKEN"
+    access_secret_key: "TWITTER_ACCESS_SECRET"
+    thumbnail_filename: "thumbnail.png"
+
   podcast:
     enabled: false
     feed_title: "金融ニュース解説ポッドキャスト"

--- a/src/providers/twitter.py
+++ b/src/providers/twitter.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict
+from urllib.parse import quote
+
+import requests
+
+from src.utils.secrets import load_secret_values
+
+
+class TwitterClient:
+    upload_url = "https://upload.twitter.com/1.1/media/upload.json"
+    tweet_url = "https://api.twitter.com/2/tweets"
+
+    def __init__(
+        self,
+        *,
+        api_key_key: str = "TWITTER_API_KEY",
+        api_secret_key: str = "TWITTER_API_SECRET",
+        access_token_key: str = "TWITTER_ACCESS_TOKEN",
+        access_secret_key: str = "TWITTER_ACCESS_SECRET",
+    ) -> None:
+        self.api_key = self._secret(api_key_key)
+        self.api_secret = self._secret(api_secret_key)
+        self.access_token = self._secret(access_token_key)
+        self.access_secret = self._secret(access_secret_key)
+
+    def post_video(
+        self,
+        *,
+        text: str,
+        video_path: Path,
+        thumbnail_path: Path | None = None,
+        chunk_size: int = 5_242_880,
+    ) -> Dict[str, Any]:
+        video_id = self._upload_video(video_path, chunk_size)
+        media_ids = [video_id]
+        thumbnail_id = None
+        if thumbnail_path and thumbnail_path.exists():
+            thumbnail_id = self._upload_image(thumbnail_path)
+            media_ids.append(thumbnail_id)
+        tweet = self._post_json(self.tweet_url, {"text": text, "media": {"media_ids": media_ids}})
+        return {"tweet": tweet, "video_media_id": video_id, "thumbnail_media_id": thumbnail_id}
+
+    def _secret(self, key: str) -> str:
+        return load_secret_values(key)[0]
+
+    def _upload_video(self, path: Path, chunk_size: int) -> str:
+        size = path.stat().st_size
+        init = self._post_form(
+            self.upload_url,
+            {
+                "command": "INIT",
+                "total_bytes": size,
+                "media_type": "video/mp4",
+                "media_category": "tweet_video",
+            },
+        )
+        media_id = init["media_id_string"]
+        segment = 0
+        with path.open("rb") as src:
+            while True:
+                chunk = src.read(chunk_size)
+                if not chunk:
+                    break
+                self._post_form(
+                    self.upload_url,
+                    {
+                        "command": "APPEND",
+                        "media_id": media_id,
+                        "segment_index": segment,
+                    },
+                    {"media": (path.name, chunk)},
+                )
+                segment += 1
+        finalize = self._post_form(self.upload_url, {"command": "FINALIZE", "media_id": media_id})
+        info = finalize.get("processing_info")
+        while info and info.get("state") in {"pending", "in_progress"}:
+            time.sleep(info.get("check_after_secs", 1))
+            status = self._get(self.upload_url, {"command": "STATUS", "media_id": media_id})
+            info = status.get("processing_info")
+        return media_id
+
+    def _upload_image(self, path: Path) -> str:
+        with path.open("rb") as src:
+            content = src.read()
+        response = self._post_form(
+            self.upload_url,
+            {"media_category": "tweet_image"},
+            {"media": (path.name, content)},
+        )
+        return response["media_id_string"]
+
+    def _oauth_headers(self, method: str, url: str, params: Dict[str, Any] | None = None) -> Dict[str, str]:
+        params = {str(k): str(v) for k, v in (params or {}).items()}
+        oauth_params = {
+            "oauth_consumer_key": self.api_key,
+            "oauth_nonce": base64.urlsafe_b64encode(os.urandom(32)).decode().rstrip("="),
+            "oauth_signature_method": "HMAC-SHA1",
+            "oauth_timestamp": str(int(time.time())),
+            "oauth_token": self.access_token,
+            "oauth_version": "1.0",
+        }
+        signature_params = dict(params)
+        signature_params.update(oauth_params)
+        items = sorted((quote(k, safe="~"), quote(v, safe="~")) for k, v in signature_params.items())
+        param_str = "&".join(f"{k}={v}" for k, v in items)
+        base_elems = [method.upper(), quote(url, safe="~"), quote(param_str, safe="~")]
+        base_string = "&".join(base_elems)
+        signing_key = "&".join([quote(self.api_secret, safe="~"), quote(self.access_secret, safe="~")])
+        digest = hmac.new(signing_key.encode(), base_string.encode(), hashlib.sha1).digest()
+        oauth_params["oauth_signature"] = base64.b64encode(digest).decode()
+        header = "OAuth " + ", ".join(
+            f'{key}="{quote(value, safe="~")}"' for key, value in sorted(oauth_params.items())
+        )
+        return {"Authorization": header}
+
+    def _post_form(
+        self,
+        url: str,
+        data: Dict[str, Any],
+        files: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        payload = {str(k): str(v) for k, v in data.items()}
+        headers = self._oauth_headers("POST", url, payload)
+        response = requests.post(url, data=payload, files=files, headers=headers)
+        response.raise_for_status()
+        return response.json()
+
+    def _post_json(self, url: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        headers = self._oauth_headers("POST", url, {})
+        headers["Content-Type"] = "application/json"
+        response = requests.post(url, headers=headers, json=payload)
+        response.raise_for_status()
+        return response.json()
+
+    def _get(self, url: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        query = {str(k): str(v) for k, v in params.items()}
+        headers = self._oauth_headers("GET", url, query)
+        response = requests.get(url, params=query, headers=headers)
+        response.raise_for_status()
+        return response.json()

--- a/src/steps/twitter.py
+++ b/src/steps/twitter.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Dict
+
+from src.core.step import Step
+from src.providers.twitter import TwitterClient
+
+
+class TwitterPoster(Step):
+    name = "post_twitter"
+    output_filename = "twitter.json"
+    is_required = False
+
+    def __init__(self, run_id: str, run_dir: Path, twitter_config: Dict | None = None) -> None:
+        super().__init__(run_id, run_dir)
+        twitter_config = twitter_config or {}
+        self.clip_duration = int(twitter_config.get("clip_duration_seconds", 60))
+        self.chunk_size = int(twitter_config.get("chunk_size", 5_242_880))
+        self.thumbnail_filename = twitter_config.get("thumbnail_filename", "thumbnail.png")
+        self.client = TwitterClient(
+            api_key_key=twitter_config.get("api_key_key", "TWITTER_API_KEY"),
+            api_secret_key=twitter_config.get("api_secret_key", "TWITTER_API_SECRET"),
+            access_token_key=twitter_config.get("access_token_key", "TWITTER_ACCESS_TOKEN"),
+            access_secret_key=twitter_config.get("access_secret_key", "TWITTER_ACCESS_SECRET"),
+        )
+
+    def execute(self, inputs: Dict[str, Path]) -> Path:
+        video_path = Path(inputs["render_video"])
+        metadata_path = Path(inputs["analyze_metadata"])
+        output_dir = self.run_dir / self.run_id
+        clip_path = output_dir / "twitter_clip.mp4"
+        clip_path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-i",
+                str(video_path),
+                "-ss",
+                "0",
+                "-t",
+                str(self.clip_duration),
+                "-c",
+                "copy",
+                str(clip_path),
+            ],
+            check=True,
+        )
+        with open(metadata_path, encoding="utf-8") as f:
+            metadata = json.load(f)
+        title = str(metadata.get("title", ""))
+        tags = metadata.get("tags") or []
+        tags_text = " ".join(tag for tag in tags[:5] if tag)
+        text = title if not tags_text else f"{title} {tags_text}".strip()
+        thumbnail_path = output_dir / self.thumbnail_filename
+        if inputs.get("generate_thumbnail"):
+            thumbnail_path = Path(inputs["generate_thumbnail"])
+        result = self.client.post_video(
+            text=text,
+            video_path=clip_path,
+            thumbnail_path=thumbnail_path if thumbnail_path.exists() else None,
+            chunk_size=self.chunk_size,
+        )
+        output_path = self.get_output_path()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(result, f, ensure_ascii=False, indent=2)
+        return output_path

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -179,6 +179,17 @@ class YouTubeStepConfig(BaseModel):
     default_tags: list[str] = Field(default_factory=list)
 
 
+class TwitterStepConfig(BaseModel):
+    enabled: bool = False
+    clip_duration_seconds: int = 60
+    chunk_size: int = 5242880
+    api_key_key: str = "TWITTER_API_KEY"
+    api_secret_key: str = "TWITTER_API_SECRET"
+    access_token_key: str = "TWITTER_ACCESS_TOKEN"
+    access_secret_key: str = "TWITTER_ACCESS_SECRET"
+    thumbnail_filename: str = "thumbnail.png"
+
+
 class PodcastStepConfig(BaseModel):
     enabled: bool = False
     feed_title: str = "金融ニュース解説ポッドキャスト"
@@ -205,6 +216,7 @@ class StepsConfig(BaseModel):
     thumbnail: ThumbnailStepConfig
     metadata: MetadataStepConfig
     youtube: YouTubeStepConfig
+    twitter: TwitterStepConfig
     podcast: PodcastStepConfig
     buzzsprout: BuzzsproutStepConfig
 


### PR DESCRIPTION
## Summary
- add an optional Twitter posting step that trims the first minute of the rendered video and tweets it after the YouTube upload completes
- implement a Twitter client that uploads video clips, optional thumbnails, and publishes the tweet using OAuth1 credentials from config secrets
- extend the workflow configuration to expose Twitter settings and wire the new step into the YouTube workflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef6d9c75208325bb1d9695df5177f4