### PR TITLE
Enforce the Issue #28 thumbnail specification

### DIFF
--- a/.github/workflows/thumbnail-spec.yml
+++ b/.github/workflows/thumbnail-spec.yml
@@ -1,0 +1,26 @@
+name: Thumbnail specification
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  issue-28-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install focused dependencies
+        run: pip install "Pillow>=12,<13" "pydantic>=2,<3" "PyYAML>=6,<7"
+      - name: Compile thumbnail implementation
+        run: python -m py_compile src/steps/thumbnail.py tests/unit/steps/test_thumbnail_spec.py
+      - name: Verify thumbnail contract
+        run: python -m pytest tests/unit/steps/test_thumbnail_spec.py -q

--- a/.github/workflows/thumbnail-spec.yml
+++ b/.github/workflows/thumbnail-spec.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install focused dependencies
-        run: pip install "Pillow>=12,<13" "pydantic>=2,<3" "PyYAML>=6,<7"
+        run: pip install "Pillow>=12,<13" "pydantic>=2,<3" "PyYAML>=6,<7" "pytest>=7,<9"
       - name: Compile thumbnail implementation
         run: python -m py_compile src/steps/thumbnail.py tests/unit/steps/test_thumbnail_spec.py
       - name: Verify thumbnail contract

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -76,14 +76,23 @@ steps:
     enabled: false
     width: 1280
     height: 720
-    background_color: "#FFE14A"
-    title_color: "#C62828"
-    subtitle_color: "#FFD166"
+    background_color: "#fef155"
+    title_color: "#EB001B"
+    subtitle_color: "#EB001B"
+    safe_margin_pct: 9
+    title_height_min_pct: 30
+    title_height_max_pct: 40
+    preview_width: 200
+    outline_inner_color: "#FFFFFF"
+    outline_inner_width: 3
+    outline_outer_color: "#000000"
+    outline_outer_width: 6
     padding: 80
     max_lines: 4
     max_chars_per_line: 12
-    title_font_size: 96
+    title_font_size: 288
     subtitle_font_size: 56
+    font_path: "assets/fonts/ZenMaruGothic-Bold.ttf"
     overlays: []
 
   thumbnail_ai:

--- a/src/steps/thumbnail.py
+++ b/src/steps/thumbnail.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import random
 from pathlib import Path
 from typing import Dict, List, Tuple
@@ -41,27 +42,32 @@ class ThumbnailGenerator(Step):
         super().__init__(run_id, run_dir)
         cfg = dict(thumbnail_config or {})
         if cfg.get("randomize_palette", True):
-            palette = random.choice(_palette_candidates(cfg))
-            cfg.update(palette)
+            candidates = _palette_candidates(cfg)
+            if candidates:
+                cfg.update(random.choice(candidates))
         self.enabled = bool(cfg.get("enabled", True))
         self.width = int(cfg.get("width", 1280))
         self.height = int(cfg.get("height", 720))
-        self.background_color = str(cfg.get("background_color", "#1a2238"))
-        self.title_color = str(cfg.get("title_color", "#FFFFFF"))
-        self.subtitle_color = str(cfg.get("subtitle_color", "#FFD166"))
-        self.show_subtitle = bool(cfg.get("show_subtitle", True))
+        self.background_color = str(cfg.get("background_color", "#fef155"))
+        self.title_color = str(cfg.get("title_color", "#EB001B"))
+        self.subtitle_color = str(cfg.get("subtitle_color", "#EB001B"))
+        self.show_subtitle = bool(cfg.get("show_subtitle", False))
         self.padding = int(cfg.get("padding", 80))
-        self.title_font_size = int(cfg.get("title_font_size", 206))
+        self.safe_margin_pct = float(cfg.get("safe_margin_pct", 9.0))
+        self.title_height_min_pct = float(cfg.get("title_height_min_pct", 30.0))
+        self.title_height_max_pct = float(cfg.get("title_height_max_pct", 40.0))
+        self.preview_width = int(cfg.get("preview_width", 200))
+        self.title_font_size = int(cfg.get("title_font_size", 360))
         self.subtitle_font_size = int(cfg.get("subtitle_font_size", 56))
-        self.max_lines = int(cfg.get("max_lines", 3))
+        self.max_lines = int(cfg.get("max_lines", 4))
         self.max_chars_per_line = int(cfg.get("max_chars_per_line", 12))
         self.font_path = cfg.get("font_path")
         self.overlay_configs = list(cfg.get("overlays", []))
         self.right_guard_band_px = int(cfg.get("right_guard_band_px", 0))
-        self.outline_inner_color = str(cfg.get("outline_inner_color", "#EB001B"))
-        self.outline_inner_width = int(cfg.get("outline_inner_width", 20))
+        self.outline_inner_color = str(cfg.get("outline_inner_color", "#FFFFFF"))
+        self.outline_inner_width = int(cfg.get("outline_inner_width", 3))
         self.outline_outer_color = str(cfg.get("outline_outer_color", "#000000"))
-        self.outline_outer_width = int(cfg.get("outline_outer_width", 20))
+        self.outline_outer_width = int(cfg.get("outline_outer_width", 6))
 
     def execute(self, inputs: Dict[str, Path | str]) -> Path:
         output_path = self.get_output_path()
@@ -78,17 +84,41 @@ class ThumbnailGenerator(Step):
         bg_rgb = getrgb(self.background_color) + (255,)
         image = Image.new("RGBA", (self.width, self.height), color=bg_rgb)
         draw = ImageDraw.Draw(image)
-        title_font = self._load_font(self.title_font_size)
-        subtitle_font = self._load_font(self.subtitle_font_size)
-        text_right = self.width - self.padding - max(0, self.right_guard_band_px)
-        title_bottom = self._render_text(draw, title, title_font, self.title_color, self.padding, text_right)
+        margin_x, margin_y = self._safe_margins()
+        text_right = self.width - margin_x - max(0, self.right_guard_band_px)
+        max_title_height = int(self.height * self.title_height_max_pct / 100)
+        title_font, actual_font_size = self._fit_title_font(title, text_right - margin_x, max_title_height)
+        title_bottom = self._render_text(
+            draw,
+            title,
+            title_font,
+            self.title_color,
+            margin_y,
+            text_right,
+            left_edge=margin_x,
+        )
+        title_height_pct = 100 * max(0, title_bottom - margin_y) / self.height
+
         if self.show_subtitle and subtitle:
-            y_offset = title_bottom + self.padding // 2
-            self._render_text(draw, subtitle, subtitle_font, self.subtitle_color, y_offset, text_right)
+            subtitle_font = self._load_font(self.subtitle_font_size)
+            y_offset = title_bottom + max(8, margin_y // 2)
+            self._render_text(
+                draw,
+                subtitle,
+                subtitle_font,
+                self.subtitle_color,
+                y_offset,
+                text_right,
+                left_edge=margin_x,
+            )
 
         for overlay in self._prepare_overlays():
             image.paste(overlay["image"], overlay["position"], mask=overlay["image"])
-        image.convert("RGB").save(output_path, format="PNG")
+
+        rgb_image = image.convert("RGB")
+        rgb_image.save(output_path, format="PNG")
+        self._save_preview(rgb_image, output_path)
+        self._save_metadata(output_path, title, actual_font_size, title_height_pct)
         return output_path
 
     def _resolve_title(self, metadata: Dict | None, script) -> str:
@@ -105,12 +135,37 @@ class ThumbnailGenerator(Step):
             return script.segments[1].text.strip() or "解説付き"
         return script.segments[0].speaker.strip() if script.segments else "解説付き"
 
+    def _safe_margins(self) -> Tuple[int, int]:
+        pct = max(0.0, min(49.0, self.safe_margin_pct)) / 100
+        return round(self.width * pct), round(self.height * pct)
+
     def _load_font(self, size: int) -> ImageFont.ImageFont:
         if self.font_path:
             font_file = Path(self.font_path)
             if font_file.exists():
                 return ImageFont.truetype(str(font_file), size)
-        return ImageFont.load_default()
+        return ImageFont.load_default(size=size)
+
+    def _fit_title_font(
+        self, text: str, max_width: int, max_height: int
+    ) -> tuple[ImageFont.ImageFont, int]:
+        max_size = max(24, self.title_font_size)
+        for size in range(max_size, 23, -4):
+            font = self._load_font(size)
+            lines = self._wrap_text(text, font, max_width)
+            if self._text_block_height(font, lines) <= max_height:
+                return font, size
+        return self._load_font(24), 24
+
+    def _text_block_height(self, font: ImageFont.ImageFont, lines: List[str]) -> int:
+        if not lines:
+            return 0
+        heights = []
+        for line in lines:
+            bbox = font.getbbox(line or " ")
+            heights.append(max(1, int(bbox[3] - bbox[1])))
+        spacing = max(4, self.padding // 4)
+        return sum(heights) + spacing * max(0, len(lines) - 1)
 
     def _prepare_overlays(self) -> List[Dict]:
         overlays = []
@@ -140,7 +195,9 @@ class ThumbnailGenerator(Step):
         elif cfg.get("width_ratio"):
             w = int(self.width * float(cfg["width_ratio"]))
             h = int(h * w / overlay.size[0])
-        return overlay.resize((max(1, w), max(1, h)), Image.LANCZOS) if (w, h) != overlay.size else overlay
+        if (w, h) == overlay.size:
+            return overlay
+        return overlay.resize((max(1, w), max(1, h)), Image.Resampling.LANCZOS)
 
     def _resolve_position(self, size: Tuple[int, int], cfg: Dict) -> Tuple[int, int]:
         anchor = str(cfg.get("anchor", "bottom_right")).lower()
@@ -162,13 +219,21 @@ class ThumbnailGenerator(Step):
         return max(0, min(self.width - w, x)), max(0, min(self.height - h, y))
 
     def _render_text(
-        self, draw: ImageDraw.ImageDraw, text: str, font: ImageFont.ImageFont, color: str, top: int, right_edge: int
+        self,
+        draw: ImageDraw.ImageDraw,
+        text: str,
+        font: ImageFont.ImageFont,
+        color: str,
+        top: int,
+        right_edge: int,
+        *,
+        left_edge: int | None = None,
     ) -> int:
-        max_width = max(self.padding, right_edge - self.padding)
+        x = self.padding if left_edge is None else left_edge
+        max_width = max(1, right_edge - x)
         lines = self._wrap_text(text, font, max_width)
         y = top
         for i, line in enumerate(lines):
-            x = self.padding
             draw.text(
                 (x, y),
                 line,
@@ -218,3 +283,27 @@ class ThumbnailGenerator(Step):
             return int(font.getlength(text))
         bbox = font.getbbox(text)
         return int(bbox[2] - bbox[0])
+
+    def _save_preview(self, image: Image.Image, output_path: Path) -> Path:
+        width = max(1, min(self.width, self.preview_width))
+        height = max(1, round(self.height * width / self.width))
+        preview_path = output_path.with_name(f"{output_path.stem}.preview.png")
+        image.resize((width, height), Image.Resampling.LANCZOS).save(preview_path, format="PNG")
+        return preview_path
+
+    def _save_metadata(self, output_path: Path, title: str, font_size: int, title_height_pct: float) -> Path:
+        metadata_path = output_path.with_name(f"{output_path.stem}.metadata.json")
+        payload = {
+            "copy": title,
+            "font_size_main": font_size,
+            "outline_white_px": self.outline_inner_width,
+            "outline_black_px": self.outline_outer_width,
+            "safe_margin_pct": self.safe_margin_pct,
+            "background_color": self.background_color,
+            "text_color": self.title_color,
+            "preview_width_px": max(1, min(self.width, self.preview_width)),
+            "title_height_pct": round(title_height_pct, 2),
+            "title_height_target_pct": [self.title_height_min_pct, self.title_height_max_pct],
+        }
+        metadata_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        return metadata_path

--- a/tests/unit/steps/test_thumbnail_spec.py
+++ b/tests/unit/steps/test_thumbnail_spec.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import yaml
+from PIL import Image
+
+from src.steps.thumbnail import ThumbnailGenerator
+
+
+def _thumbnail_config() -> dict:
+    raw = yaml.safe_load(Path("config/default.yaml").read_text(encoding="utf-8"))
+    cfg = dict(raw["steps"]["thumbnail"])
+    cfg["enabled"] = True
+    cfg["randomize_palette"] = False
+    return cfg
+
+
+def test_default_thumbnail_contract_matches_issue_28() -> None:
+    cfg = _thumbnail_config()
+    assert cfg["background_color"] == "#fef155"
+    assert cfg["title_color"] == "#EB001B"
+    assert cfg["outline_inner_color"] == "#FFFFFF"
+    assert cfg["outline_inner_width"] in (2, 3)
+    assert cfg["outline_outer_color"] == "#000000"
+    assert 4 <= cfg["outline_outer_width"] <= 6
+    assert cfg["outline_outer_width"] > cfg["outline_inner_width"]
+    assert 8 <= cfg["safe_margin_pct"] <= 10
+    assert cfg["preview_width"] == 200
+    assert cfg["title_height_min_pct"] == 30
+    assert cfg["title_height_max_pct"] == 40
+
+
+def test_render_order_is_black_then_white_then_red(tmp_path: Path) -> None:
+    generator = ThumbnailGenerator("run", tmp_path, _thumbnail_config())
+
+    class Font:
+        def getlength(self, text: str) -> int:
+            return len(text) * 20
+
+    class Draw:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def text(self, xy, text, **kwargs) -> None:
+            self.calls.append(kwargs)
+
+        def textbbox(self, xy, text, font=None):
+            return (xy[0], xy[1], xy[0] + 100, xy[1] + 40)
+
+    draw = Draw()
+    generator._render_text(draw, "速報", Font(), generator.title_color, 60, 1160, left_edge=115)
+    assert [call["fill"] for call in draw.calls] == ["#000000", "#FFFFFF", "#EB001B"]
+    assert draw.calls[0]["stroke_width"] == 6
+    assert draw.calls[1]["stroke_width"] == 3
+    assert "stroke_width" not in draw.calls[2]
+
+
+def test_render_emits_mobile_preview_and_audit_metadata(tmp_path: Path) -> None:
+    generator = ThumbnailGenerator("run", tmp_path, _thumbnail_config())
+    script = SimpleNamespace(segments=[SimpleNamespace(text="日銀利上げ", speaker="春日部つむぎ")])
+
+    with patch("src.steps.thumbnail.load_script", return_value=script):
+        output = generator.execute({"generate_script": Path("unused.json")})
+
+    assert output.exists()
+    with Image.open(output) as image:
+        assert image.size == (1280, 720)
+        assert image.getpixel((0, 0)) == (254, 241, 85)
+
+    preview = output.with_name("thumbnail.preview.png")
+    assert preview.exists()
+    with Image.open(preview) as image:
+        assert image.size == (200, 112)
+
+    metadata_path = output.with_name("thumbnail.metadata.json")
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert metadata["copy"] == "日銀利上げ"
+    assert metadata["outline_white_px"] == 3
+    assert metadata["outline_black_px"] == 6
+    assert metadata["safe_margin_pct"] == 9
+    assert metadata["preview_width_px"] == 200
+    assert metadata["background_color"] == "#fef155"
+    assert metadata["text_color"] == "#EB001B"
+    assert metadata["title_height_pct"] <= 40


### PR DESCRIPTION
## Summary

- align the deterministic thumbnail preset with Issue #28 (`#fef155` background, `#EB001B` text, 3 px white inner outline, 6 px black outer outline)
- enforce 9% safe margins and adapt the main-title font to the 30–40% target height band
- render the required black → white → red text layers
- emit `thumbnail.preview.png` at 200 px width and `thumbnail.metadata.json` with the requested audit fields
- add focused regression tests and a lightweight GitHub Actions workflow

## Root cause

The repository already had a three-pass Pillow renderer, but its checked-in defaults did not match the issue: the background/title colors differed, the inner outline default was red, both outline widths defaulted to 20 px in code, the configured margin was below the requested 8–10%, and no mobile preview or audit metadata was generated.

## Validation

The new workflow compiles the thumbnail implementation and runs the focused Issue #28 tests using Pillow 12.x, Pydantic 2.x, PyYAML 6.x and pytest.

Primary API reference: Pillow `ImageDraw.text()` supports `stroke_width` and `stroke_fill`, which are used for the staged outline rendering.

Closes #28