### PR TITLE
Paginate subtitles at sentence boundaries

### DIFF
--- a/.github/workflows/default-config-safety.yml
+++ b/.github/workflows/default-config-safety.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install "pydantic>=2,<3" PyYAML Pillow
+      - run: pip install "pydantic>=2,<3" PyYAML Pillow ffmpeg-python pydub
       - name: Validate publication defaults
         run: |
           python - <<'PY'

--- a/.github/workflows/default-config-safety.yml
+++ b/.github/workflows/default-config-safety.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install "pydantic>=2,<3" PyYAML
+      - run: pip install "pydantic>=2,<3" PyYAML Pillow
       - name: Validate publication defaults
         run: |
           python - <<'PY'
@@ -39,3 +39,5 @@ jobs:
           PY
       - name: Validate context-note history
         run: python -m unittest tests/unit/test_context_notes.py -v
+      - name: Validate subtitle pagination
+        run: python -m unittest tests/unit/steps/test_subtitle_pagination.py -v

--- a/src/steps/subtitle.py
+++ b/src/steps/subtitle.py
@@ -12,6 +12,7 @@ from src.core.step import Step
 class SubtitleFormatter(Step):
     name = "prepare_subtitles"
     output_filename = "subtitles.srt"
+    _PAGE_BREAK_PATTERN = re.compile(r"(?<=[。！？!?])")
 
     def __init__(
         self,
@@ -87,14 +88,25 @@ class SubtitleFormatter(Step):
 
         timestamps = []
         current_time = 0.0
-        for i, (seg, clean_text) in enumerate(cleaned_segments):
-            char_ratio = len(clean_text) / total_chars if total_chars > 0 else 0.0
+        for i, (_, clean_text) in enumerate(cleaned_segments):
+            char_ratio = len(clean_text) / total_chars
             duration = available * char_ratio if available > 0 else 0.0
-            end_time = current_time + duration
+            segment_end = current_time + duration
             if i == len(cleaned_segments) - 1:
-                end_time = audio_duration
-            timestamps.append({"start": current_time, "end": end_time, "text": clean_text})
-            current_time = end_time + (gap if i < len(cleaned_segments) - 1 else 0)
+                segment_end = audio_duration
+
+            pages = self._paginate_text(clean_text)
+            page_chars = sum(len(page) for page in pages)
+            page_start = current_time
+            for page_index, page in enumerate(pages):
+                if page_index == len(pages) - 1:
+                    page_end = segment_end
+                else:
+                    page_end = page_start + (segment_end - current_time) * len(page) / page_chars
+                timestamps.append({"start": page_start, "end": page_end, "text": page})
+                page_start = page_end
+
+            current_time = segment_end + (gap if i < len(cleaned_segments) - 1 else 0)
         return timestamps
 
     def _generate_srt(self, timestamps: list[Dict]) -> str:
@@ -114,19 +126,26 @@ class SubtitleFormatter(Step):
         ms = int((seconds % 1) * 1000)
         return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
 
-    def _wrap_text(self, text: str) -> List[str]:
-        limit = max(self.max_chars_per_line, 1)
-        wrapped: List[str] = []
+    def _paginate_text(self, text: str) -> List[str]:
+        """Split subtitle text into sentence-aware pages with at most two lines."""
+
+        page_capacity = max(self.max_chars_per_line, 1) * 2
+        pages: List[str] = []
         for raw_line in text.split("\n"):
             line = raw_line.strip()
             if not line:
-                wrapped.append("")
                 continue
-            start = 0
-            while start < len(line):
-                wrapped.append(line[start : start + limit])
-                start += limit
-        return wrapped or [""]
+            sentences = [part.strip() for part in self._PAGE_BREAK_PATTERN.split(line) if part.strip()]
+            for sentence in sentences:
+                start = 0
+                while start < len(sentence):
+                    pages.append(sentence[start : start + page_capacity])
+                    start += page_capacity
+        return pages or [""]
+
+    def _wrap_text(self, text: str) -> List[str]:
+        limit = max(self.max_chars_per_line, 1)
+        return [text[start : start + limit] for start in range(0, len(text), limit)] or [""]
 
     def _clean_text(self, text: str) -> str:
         cleaned = re.sub(r"\s*\(間\)\s*", " ", text)

--- a/tests/unit/steps/test_subtitle_pagination.py
+++ b/tests/unit/steps/test_subtitle_pagination.py
@@ -1,0 +1,39 @@
+import unittest
+from types import SimpleNamespace
+
+from src.steps.subtitle import SubtitleFormatter
+
+
+class SubtitlePaginationTest(unittest.TestCase):
+    def setUp(self):
+        self.formatter = object.__new__(SubtitleFormatter)
+        self.formatter.max_chars_per_line = 5
+
+    def test_sentence_endings_create_separate_pages(self):
+        self.assertEqual(
+            self.formatter._paginate_text("最初です。次です！最後?"),
+            ["最初です。", "次です！", "最後?"],
+        )
+
+    def test_long_sentence_is_hard_split_to_two_line_capacity(self):
+        self.assertEqual(
+            self.formatter._paginate_text("12345678901"),
+            ["1234567890", "1"],
+        )
+
+    def test_generated_cues_are_contiguous_and_end_at_audio_duration(self):
+        script = SimpleNamespace(segments=[SimpleNamespace(text="最初です。次です。")])
+        cues = self.formatter._calculate_timestamps(script, 10.0)
+
+        self.assertEqual([cue["text"] for cue in cues], ["最初です。", "次です。"])
+        self.assertEqual(cues[0]["start"], 0.0)
+        self.assertEqual(cues[0]["end"], cues[1]["start"])
+        self.assertEqual(cues[-1]["end"], 10.0)
+
+    def test_each_page_wraps_to_at_most_two_lines(self):
+        for page in self.formatter._paginate_text("12345678901。短い。"):
+            self.assertLessEqual(len(self.formatter._wrap_text(page)), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- refresh Issue #25 implementation on current `main` to avoid the stale/diverged PR #44 branch
- split subtitle cues after Japanese and ASCII sentence-ending punctuation (`。！？!?`)
- hard-split a sentence at `max_chars_per_line × 2`, so each generated SRT cue wraps to at most two lines
- preserve each source segment's time window and distribute it continuously across generated pages
- add deterministic regression tests and run them in the existing Default config safety workflow

## Validation contract
- punctuation creates separate subtitle pages
- overlong unpunctuated text is split at two-line capacity
- generated cue intervals remain contiguous and finish at the source audio duration
- every generated page wraps to at most two lines

## Primary-source alignment
YouTube documents SubRip (`.srt`) as a supported basic caption format and states that caption files contain timestamps controlling when each line is displayed. YouTube also documents that a blank line in transcript input forces a new caption. The implementation therefore treats pagination as explicit timed caption cues rather than relying on an LLM to insert visual line breaks.

Supersedes #44.

Closes #25