### PR TITLE
Record immutable prompt versions in workflow state

### DIFF
--- a/.github/workflows/default-config-safety.yml
+++ b/.github/workflows/default-config-safety.yml
@@ -37,6 +37,8 @@ jobs:
           assert steps["hatena"]["enabled"] is False
           assert raw["automation"]["enabled"] is False
           PY
+      - name: Validate prompt version provenance
+        run: python -m unittest tests/unit/test_prompt_version.py -v
       - name: Validate context-note history
         run: python -m unittest tests/unit/test_context_notes.py -v
       - name: Validate subtitle pagination

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -8,6 +8,7 @@ from typing import Dict, Iterable, List
 from src.core.state import WorkflowResult, WorkflowState
 from src.core.step import Step
 from src.tracking import AimTracker
+from src.utils.prompt_version import prompt_bundle_version
 
 
 class WorkflowOrchestrator:
@@ -16,6 +17,14 @@ class WorkflowOrchestrator:
         self.steps: List[Step] = list(steps)
         self.run_dir = Path(run_dir)
         self.state = WorkflowState.load_or_create(run_id, self.run_dir)
+
+        current_prompt_version = prompt_bundle_version()
+        if self.state.prompt_version and self.state.prompt_version != current_prompt_version:
+            raise ValueError(
+                "Prompt bundle changed since this run started: "
+                f"state={self.state.prompt_version} current={current_prompt_version}"
+            )
+        self.state.prompt_version = current_prompt_version
 
     def execute(self) -> WorkflowResult:
         start_time = datetime.now()

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 class WorkflowState(BaseModel):
     run_id: str
     aim_run_id: str | None = None
+    prompt_version: str | None = None
     status: Literal["running", "completed", "failed", "partial"] = "running"
     completed_steps: List[str] = Field(default_factory=list)
     outputs: Dict[str, str] = Field(default_factory=dict)

--- a/src/utils/prompt_version.py
+++ b/src/utils/prompt_version.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+DEFAULT_PROMPTS_PATH = Path(__file__).parent.parent.parent / "config" / "prompts.yaml"
+
+
+def prompt_bundle_version(prompts_path: str | Path | None = None) -> str:
+    """Return an immutable content version for the prompt bundle."""
+    path = Path(prompts_path) if prompts_path is not None else DEFAULT_PROMPTS_PATH
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    return f"sha256:{digest}"

--- a/tests/unit/test_prompt_version.py
+++ b/tests/unit/test_prompt_version.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.core.state import WorkflowState
+from src.utils.prompt_version import prompt_bundle_version
+
+
+class PromptVersionTests(unittest.TestCase):
+    def test_prompt_version_is_content_addressed_and_changes_with_content(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            prompts = Path(tmp) / "prompts.yaml"
+            first = b"script_generation:\n  user_template: first\n"
+            prompts.write_bytes(first)
+
+            expected = f"sha256:{hashlib.sha256(first).hexdigest()}"
+            self.assertEqual(prompt_bundle_version(prompts), expected)
+            self.assertEqual(prompt_bundle_version(prompts), expected)
+
+            prompts.write_text("script_generation:\n  user_template: second\n", encoding="utf-8")
+            self.assertNotEqual(prompt_bundle_version(prompts), expected)
+
+    def test_workflow_state_persists_prompt_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp)
+            version = "sha256:" + "a" * 64
+            state = WorkflowState(run_id="run-1", prompt_version=version)
+            state.save(run_dir)
+
+            payload = json.loads((run_dir / "run-1" / "state.json").read_text(encoding="utf-8"))
+            self.assertEqual(payload["prompt_version"], version)
+
+            restored = WorkflowState.load_or_create("run-1", run_dir)
+            self.assertEqual(restored.prompt_version, version)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #30

## What changed
- derive a deterministic `prompt_version` from the SHA-256 digest of the complete `config/prompts.yaml` bytes
- persist that version in each workflow `state.json`
- fail closed when a previously started run is resumed after the prompt bundle has changed
- add regression tests for content-addressed versioning and state round-tripping
- run the regression test in the existing `Default config safety` CI

## Design
The issue proposes copied `v1.0.yaml` / `v1.1.yaml` files plus a `latest` symlink, while also warning about repository/context bloat. This implementation uses the prompt bundle content itself as the immutable version (`sha256:<digest>`). Git history retains the corresponding prompt contents without duplicating the ~23 KB prompt bundle for each revision, and runs can be grouped by the exact prompt digest for A/B or quality analysis.

## Verification
- regression test covers stable digest, digest change on content change, and `state.json` persistence
- existing workflow now executes that regression on pull requests

Primary reference: Python `hashlib` documents `sha256()` and `hexdigest()` for deterministic byte-message digests: https://docs.python.org/3/library/hashlib.html